### PR TITLE
Create new date for finDate in lib.calculateAmortization

### DIFF
--- a/finance.js
+++ b/finance.js
@@ -231,7 +231,7 @@
 				schedule = [],
 				currInterest = null,
 				currPrinciple = null,
-				currDate = (finDate !== undefined && finDate.constructor === Date)? finDate : (new Date());
+				currDate = (finDate !== undefined && finDate.constructor === Date)? new Date(finDate) : (new Date());
 			
 			for(var i=0; i<finMonths; i++){
 				currInterest = balance * finInterest/1200;


### PR DESCRIPTION
I found when using the library in a web page that modifications to the inputs that would cause the amortization table to be recalculated were causing starting date to be modified in the calculation (if you were to change another input, your returned array would start at the end of the first calculated amortization).  In experimenting with my local code, I found I was able to protect my starting date from the modification made to currDate in the amortization calculation for loop.
I'm not aware of any adverse side affect / tradeoff in making this change other than the temporary allocation of a new variable (copy by value) vice copying by reference.
