### PR TITLE
Early payoff calculator

### DIFF
--- a/finance.js
+++ b/finance.js
@@ -179,52 +179,52 @@
 			return result;
 		};
   
-    // calculate time and money savings by paying extra
+	// calculate time and money savings by paying extra
 	lib.calculateEarlyPayoff = function(finAmount, finInterest, finMonths, finRemainingMonths, finExtraPay, finMonthlyPay){
-      
-        var principle1 = finAmount, interest1 = 0, principle2 = finAmount, interest2 = 0;
-        var ep;
-        var mRate = finInterest / 1200;
-        var paidOff = finMonths;
+	  
+		var principle1 = finAmount, interest1 = 0, principle2 = finAmount, interest2 = 0;
+		var ep;
+		var mRate = finInterest / 1200;
+		var paidOff = finMonths;
 
-        for (months=1; months<=finMonths; months++)
-        {
-            if ( months > (finMonths-finRemainingMonths)) {
-                ep = finExtraPay;
-            }
-            else {
-                ep = 0;
-            }
+		for (months=1; months<=finMonths; months++)
+		{
+			if ( months > (finMonths-finRemainingMonths)) {
+				ep = finExtraPay;
+			}
+			else {
+				ep = 0;
+			}
 			var mi1 = mRate * principle1;
 			mi1 = Math.round(mi1 * 100) / 100;
-            interest1 += mi1;
-            principle1 -= ( finMonthlyPay - mi1 );
+			interest1 += mi1;
+			principle1 -= ( finMonthlyPay - mi1 );
 
-            if ( principle2 > 0 )
-            {
+			if ( principle2 > 0 )
+			{
 				var mi2 = mRate * principle2;
 				mi2 = Math.round(mi2 * 100) / 100;
-                interest2 += mi2;
+				interest2 += mi2;
 				principle2 -= ( finMonthlyPay - mi2 + ep );
 				principle2 = Math.round(principle2 * 100) / 100;
 				
-                if ( principle2 <= 0 ) {
-                    principle2 = 0;
-                    paidOff = months;
-                }
-            }
-        }
+				if ( principle2 <= 0 ) {
+					principle2 = 0;
+					paidOff = months;
+				}
+			}
+		}
 
-        var timeDifference = finMonths - paidOff;
-        var y = parseInt( timeDifference/12, 10 );	
-        months = timeDifference%12;
-      
-        return {
-            saving: Math.round((interest1 - interest2) * 100) / 100,
-            years: y,
-            months: months
-        };
-    };
+		var timeDifference = finMonths - paidOff;
+		var y = parseInt( timeDifference/12, 10 );	
+		months = timeDifference%12;
+	  
+		return {
+			saving: Math.round((interest1 - interest2) * 100) / 100,
+			years: y,
+			months: months
+		};
+	};
 
 	// get an amortization schedule [ { principle: 0, interest: 0, payment: 0, paymentToPrinciple: 0, paymentToInterest: 0}, {}, {}...]
 	lib.calculateAmortization = function(finAmount, finMonths, finInterest, finDate){

--- a/finance.js
+++ b/finance.js
@@ -179,7 +179,7 @@
 			return result;
 		};
   
-      //	calculate time and money savings by paying extra
+    // calculate time and money savings by paying extra
 	lib.calculateEarlyPayoff = function(finAmount, finInterest, finMonths, finRemainingMonths, finExtraPay, finMonthlyPay){
       
         var principle1 = finAmount, interest1 = 0, principle2 = finAmount, interest2 = 0;
@@ -187,7 +187,7 @@
         var mRate = finInterest / 1200;
         var paidOff = finMonths;
 
-        for (months=1; months<finMonths; months++)
+        for (months=1; months<=finMonths; months++)
         {
             if ( months > (finMonths-finRemainingMonths)) {
                 ep = finExtraPay;
@@ -195,15 +195,19 @@
             else {
                 ep = 0;
             }
-            var mi1 = mRate * principle1;
+			var mi1 = mRate * principle1;
+			mi1 = Math.round(mi1 * 100) / 100;
             interest1 += mi1;
             principle1 -= ( finMonthlyPay - mi1 );
 
             if ( principle2 > 0 )
             {
-                var mi2 = mRate * principle2;
+				var mi2 = mRate * principle2;
+				mi2 = Math.round(mi2 * 100) / 100;
                 interest2 += mi2;
-                principle2 -= ( finMonthlyPay - mi2 + ep );
+				principle2 -= ( finMonthlyPay - mi2 + ep );
+				principle2 = Math.round(principle2 * 100) / 100;
+				
                 if ( principle2 <= 0 ) {
                     principle2 = 0;
                     paidOff = months;
@@ -216,7 +220,7 @@
         months = timeDifference%12;
       
         return {
-            saving: interest1 - interest2,
+            saving: Math.round((interest1 - interest2) * 100) / 100,
             years: y,
             months: months
         };


### PR DESCRIPTION
I found an anomaly with the early payoff calculator recently and wanted to fix. It was a combination of rounding and an iteration issue. 

Description of the problem:

If you supplied the following data:

finAmount = 15,000 
finInterest = 5%
finMonths = 60
finRemainingMonths = 24
finExtraPay = 100
finMonthlyPay = 283.07

The result should be 89.70 but the function returns 88.51.

The issue is mostly due to function not calculating the interest for last month on [line 190](https://github.com/trentrichardson/FinanceJs/pull/5/commits/d68e9044c73e3c5651842566723821702b685bcb#diff-9a02ef7ab867d875882e3312852893a7L190).